### PR TITLE
Fixed bug where player started moving before updating the sprite

### DIFF
--- a/core/src/me/lihq/game/people/AbstractPerson.java
+++ b/core/src/me/lihq/game/people/AbstractPerson.java
@@ -181,6 +181,7 @@ public abstract class AbstractPerson extends Sprite
         this.animTimer = 0f;
 
         this.state = PersonState.WALKING;
+        updateTextureRegion();
     }
 
 


### PR DESCRIPTION
Added call to updateTextureRegion() at the end of initialiseMove() to
update the sprite.