### PR TITLE
False accusation causes NPC to ignore detective

### DIFF
--- a/core/assets/people/NPCs/Colin.JSON
+++ b/core/assets/people/NPCs/Colin.JSON
@@ -5,6 +5,7 @@
     "introduction": "Hello young detective!",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Sorry my feet are a little smaller than that.",
     "Small Footprint": "That does look similar to my foot size.",
     "Glasses": "I do wear glasses yes.",

--- a/core/assets/people/NPCs/Diana.JSON
+++ b/core/assets/people/NPCs/Diana.JSON
@@ -15,6 +15,7 @@
     "introduction": "Hello, what do you want?!",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Nope, not my size",
     "Small Footprint": "These would be sufficient for me I guess.",
     "Glasses": "Glasses? Why would I need glasses!",

--- a/core/assets/people/NPCs/Lily.JSON
+++ b/core/assets/people/NPCs/Lily.JSON
@@ -15,6 +15,7 @@
     "introduction": "Hello",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Bit too big for me friend, try somebody else maybe.",
     "Small Footprint": "Looks like it could be mine!",
     "Glasses": "Unfortunately yes I do need glasses.",

--- a/core/assets/people/NPCs/Mary.JSON
+++ b/core/assets/people/NPCs/Mary.JSON
@@ -6,6 +6,7 @@
     "introduction": "Hello",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Those would fit yes, maybe you should give me them.",
     "Small Footprint": "Not mine, way too small for me.",
     "Glasses": "Not sure why it matters but yes.",

--- a/core/assets/people/NPCs/Mike.JSON
+++ b/core/assets/people/NPCs/Mike.JSON
@@ -14,6 +14,7 @@
     "introduction": "Hi, have you seen my robot? It seems to have gone astray...",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Those would fit me I think.",
     "Small Footprint": "Sorry, bit too small for me.",
     "Glasses": "Yes I do need glasses these days.",

--- a/core/assets/people/NPCs/Will.JSON
+++ b/core/assets/people/NPCs/Will.JSON
@@ -7,6 +7,7 @@
     "introduction": "Hello",
     "Ignored Initial": "##INITIAL IGNORE##",
     "ignored Return": "##IGNORED & RETURNED##",
+    "Falsely Accused": "##FALSELY ACCUSED##",
     "Big Footprint": "Oh yes I could fit into those.",
     "Small Footprint": "Too small for me.",
     "Glasses": "No I do not have glasses.",

--- a/core/src/me/lihq/game/ConversationManagement.java
+++ b/core/src/me/lihq/game/ConversationManagement.java
@@ -69,12 +69,15 @@ public class ConversationManagement
         player.canMove = false;
         player.inConversation = true;
 
-        if (!tempNPC.ignored) {
-            //Introduction
+        if (tempNPC.accused) {
+            speechboxMngr.addSpeechBox(new SpeechBox(tempNPC.getName(), tempNPC.getSpeech("Falsely Accused"), 2));
+            finishConversation();
+
+        } else if (!tempNPC.ignored) {
             speechboxMngr.addSpeechBox(new SpeechBox(this.player.getName(), this.player.getSpeech("Introduction"), 1));
             speechboxMngr.addSpeechBox(new SpeechBox(this.tempNPC.getName(), this.tempNPC.getSpeech("Introduction"), 1));
-
             queryQuestionType();
+
         } else {
             speechboxMngr.addSpeechBox(new SpeechBox(tempNPC.getName(), tempNPC.getSpeech("Ignored Return"), 2));
             finishConversation();
@@ -158,7 +161,8 @@ public class ConversationManagement
             speechboxMngr.addSpeechBox(new SpeechBox("You found the killer well done", -1));
             finishConversation();
         } else {
-            speechboxMngr.addSpeechBox(new SpeechBox("They are clearly not the killer, just look at them.", 5));
+            speechboxMngr.addSpeechBox(new SpeechBox(tempNPC.getName(), tempNPC.getSpeech("Falsely Accused"), 2));
+            this.tempNPC.accused = true;
             finishConversation();
         }
     }

--- a/core/src/me/lihq/game/people/NPC.java
+++ b/core/src/me/lihq/game/people/NPC.java
@@ -39,6 +39,9 @@ public class NPC extends AbstractPerson
     // Used to track whether the NPC has been ignored
     public boolean ignored = false;
 
+    // Used to track whether the NPC has been accused, so they can ignore the player after a false accusation
+    public boolean accused = false;
+
     /**
      * This stores the players personality {@link me.lihq.game.people.AbstractPerson.Personality}
      */


### PR DESCRIPTION
NPCs have an "accused" property to track whether they've been accused. If they have been, the player is unable to converse with them for the rest of the game, as per the requirements.